### PR TITLE
Allow chaining IP-Adapters

### DIFF
--- a/attention_processor.py
+++ b/attention_processor.py
@@ -28,8 +28,8 @@ class IPAFluxAttnProcessor2_0(nn.Module):
         num_heads,
         query,
         image_emb: torch.FloatTensor,
-        t: torch.FloatTensor
-    ) -> torch.FloatTensor:
+        t: torch.FloatTensor|torch.Tensor
+    ) -> torch.FloatTensor|torch.Tensor|None:
         # only apply IPA if timestep is within range
         if self.timestep_range is not None:
             if t[0] > self.timestep_range[0] or t[0] < self.timestep_range[1]:

--- a/flux/layers.py
+++ b/flux/layers.py
@@ -3,10 +3,11 @@ from torch import Tensor, nn
 
 from .math import attention
 from comfy.ldm.flux.layers import DoubleStreamBlock, SingleStreamBlock
+from ..attention_processor import IPAFluxAttnProcessor2_0
 import comfy.model_management
 
 class DoubleStreamBlockIPA(nn.Module):
-    def __init__(self, original_block: DoubleStreamBlock, ip_adapter, image_emb):
+    def __init__(self, original_block: DoubleStreamBlock, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):
         super().__init__()
 
         mlp_hidden_dim  = original_block.img_mlp[0].out_features
@@ -81,7 +82,7 @@ class SingleStreamBlockIPA(nn.Module):
     https://arxiv.org/abs/2302.05442 and adapted modulation interface.
     """
 
-    def __init__(self, original_block: SingleStreamBlock, ip_adapter, image_emb):
+    def __init__(self, original_block: SingleStreamBlock, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):
         super().__init__()
         self.hidden_dim = original_block.hidden_size
         self.num_heads = original_block.num_heads

--- a/flux/layers.py
+++ b/flux/layers.py
@@ -7,7 +7,7 @@ from ..attention_processor import IPAFluxAttnProcessor2_0
 import comfy.model_management
 
 class DoubleStreamBlockIPA(nn.Module):
-    def __init__(self, original_block: DoubleStreamBlock, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):
+    def __init__(self, original_block: DoubleStreamBlock, ip_adapter: list[IPAFluxAttnProcessor2_0], image_emb):
         super().__init__()
 
         mlp_hidden_dim  = original_block.img_mlp[0].out_features
@@ -29,8 +29,8 @@ class DoubleStreamBlockIPA(nn.Module):
         self.txt_norm2 = original_block.txt_norm2
         self.txt_mlp = original_block.txt_mlp
 
-        self.ip_adapter = [ip_adapter]
-        self.image_emb = [image_emb]
+        self.ip_adapter = ip_adapter
+        self.image_emb = image_emb
         self.device = comfy.model_management.get_torch_device()
 
     def add_adapter(self, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):
@@ -88,7 +88,7 @@ class SingleStreamBlockIPA(nn.Module):
     https://arxiv.org/abs/2302.05442 and adapted modulation interface.
     """
 
-    def __init__(self, original_block: SingleStreamBlock, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):
+    def __init__(self, original_block: SingleStreamBlock, ip_adapter: list[IPAFluxAttnProcessor2_0], image_emb):
         super().__init__()
         self.hidden_dim = original_block.hidden_size
         self.num_heads = original_block.num_heads
@@ -108,8 +108,8 @@ class SingleStreamBlockIPA(nn.Module):
         self.mlp_act = original_block.mlp_act
         self.modulation = original_block.modulation
 
-        self.ip_adapter = [ip_adapter]
-        self.image_emb = [image_emb]
+        self.ip_adapter = ip_adapter
+        self.image_emb = image_emb
         self.device = comfy.model_management.get_torch_device()
 
     def add_adapter(self, ip_adapter: IPAFluxAttnProcessor2_0, image_emb):

--- a/flux/layers.py
+++ b/flux/layers.py
@@ -67,7 +67,7 @@ class DoubleStreamBlockIPA(nn.Module):
             ip_hidden_states = adapter(self.num_heads, img_q, image, t)
             if ip_hidden_states is not None:
                 ip_hidden_states = ip_hidden_states.to(self.device)
-            img_attn = img_attn + ip_hidden_states
+                img_attn = img_attn + ip_hidden_states
 
         # calculate the img bloks
         img = img + img_mod1.gate * self.img_attn.proj(img_attn)
@@ -133,7 +133,7 @@ class SingleStreamBlockIPA(nn.Module):
             ip_hidden_states = adapter(self.num_heads, q, image, t)
             if ip_hidden_states is not None:
                 ip_hidden_states = ip_hidden_states.to(self.device)
-            attn = attn + ip_hidden_states
+                attn = attn + ip_hidden_states
 
         # compute activation in mlp stream, cat again and run second linear layer
         output = self.linear2(torch.cat((attn, self.mlp_act(mlp)), 2))

--- a/ipadapter_flux.py
+++ b/ipadapter_flux.py
@@ -1,4 +1,3 @@
-
 import torch
 import os
 import logging

--- a/ipadapter_flux.py
+++ b/ipadapter_flux.py
@@ -7,7 +7,7 @@ from transformers import AutoProcessor, SiglipVisionModel
 from PIL import Image
 import numpy as np
 from .attention_processor import IPAFluxAttnProcessor2_0
-from .utils import is_model_pathched, FluxUpdateModules
+from .utils import is_model_patched, FluxUpdateModules
 
 MODELS_DIR = os.path.join(folder_paths.models_dir, "ipadapter-flux")
 if "ipadapter-flux" not in folder_paths.folder_names_and_paths:
@@ -153,7 +153,7 @@ class ApplyIPAdapterFlux:
             pil_image=pil_image, clip_image_embeds=None
         )
         # set model
-        is_patched = is_model_pathched(model.model)
+        is_patched = is_model_patched(model.model)
         bi = model.clone()
         FluxUpdateModules(bi, ip_attn_procs, image_prompt_embeds, is_patched)
         return (bi,)

--- a/utils.py
+++ b/utils.py
@@ -18,7 +18,7 @@ def FluxUpdateModules(bi, ip_attn_procs, image_emb, is_patched):
         temp_layer=SingleStreamBlockIPA(flux_model.diffusion_model.single_blocks[i],ip_attn_procs[f"single_blocks.{i}"],image_emb)
         bi.add_object_patch(f"diffusion_model.single_blocks.{i}",temp_layer)
         
-def is_model_pathched(model):
+def is_model_patched(model):
     def test(mod):
         if isinstance(mod, DoubleStreamBlockIPA):
             return True

--- a/utils.py
+++ b/utils.py
@@ -38,7 +38,7 @@ def forward_orig_ipa(
     txt_ids: Tensor,
     timesteps: Tensor,
     y: Tensor,
-    guidance: Tensor = None,
+    guidance: Tensor|None = None,
     control=None,
     transformer_options={},
 ) -> Tensor:


### PR DESCRIPTION
The existing code only allows for one adapter to be loaded at a time. 
This PR allows the Single/DoubleStreamBlockIPA-s to apply multiple IP adapters to the same model, just by chaining together `ApplyIPAdapterFlux` nodes.
The implementation is very naive: each ip-adapter applies attention separately, and then the results are added together within each block. If others find this useful, I could add an option to merge the IP attention calls (in my experience, better results, but more code complexity).