### PR TITLE
Fix: IPAdapter Path Resolution When Using extra_paths 

### DIFF
--- a/ipadapter_flux.py
+++ b/ipadapter_flux.py
@@ -13,6 +13,8 @@ if "ipadapter-flux" not in folder_paths.folder_names_and_paths:
     current_paths = [MODELS_DIR]
 else:
     current_paths, _ = folder_paths.folder_names_and_paths["ipadapter-flux"]
+    MODELS_DIR = current_paths[0]
+    
 folder_paths.folder_names_and_paths["ipadapter-flux"] = (current_paths, folder_paths.supported_pt_extensions)
 
 class MLPProjModel(torch.nn.Module):

--- a/ipadapter_flux_advanced.py
+++ b/ipadapter_flux_advanced.py
@@ -13,6 +13,8 @@ if "ipadapter-flux" not in folder_paths.folder_names_and_paths:
     current_paths = [MODELS_DIR]
 else:
     current_paths, _ = folder_paths.folder_names_and_paths["ipadapter-flux"]
+    MODELS_DIR = current_paths[0]
+    
 folder_paths.folder_names_and_paths["ipadapter-flux"] = (current_paths, folder_paths.supported_pt_extensions)
 
 class MLPProjModelAdvanced(torch.nn.Module):


### PR DESCRIPTION
Hi, I noticed that when loading IPAdapter from a RunPod network volume using extra_paths, it still checks for the IPAdapter files inside the default comfy/models folder. This behavior prevented proper loading. I was able to resolve it with a fix, so I wanted to suggest updating this behavior if possible to ensure extra_paths are properly respected.

Thank you!