### PR TITLE
Fix AttributeError: 'DoubleStreamBlock' object has no attribute 'flip…

### DIFF
--- a/flux/layers.py
+++ b/flux/layers.py
@@ -28,7 +28,7 @@ class DoubleStreamBlockIPA(nn.Module):
 
         self.txt_norm2 = original_block.txt_norm2
         self.txt_mlp = original_block.txt_mlp
-        self.flipped_img_txt = original_block.flipped_img_txt
+        self.flipped_img_txt = getattr(original_block, "flipped_img_txt", False)  # <--
 
         self.ip_adapter = ip_adapter
         self.image_emb = image_emb


### PR DESCRIPTION
…ped_img_txt'

I'm not completely sure about the exact cause, but changing it like this fixed the `AttributeError: 'DoubleStreamBlock' object has no attribute 'flipped_img_txt'` and now it works perfectly.

Hope this helps!